### PR TITLE
JNettyTcpConnector 默认构造方法优化 & jupiter/pom.xml中properties增加project.build.sourceEncoding属性

### DIFF
--- a/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyTcpConnector.java
+++ b/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyTcpConnector.java
@@ -105,7 +105,9 @@ public class JNettyTcpConnector extends NettyTcpConnector {
     private final ProtocolEncoder encoder = new ProtocolEncoder();
     private final ConnectorHandler handler = new ConnectorHandler();
 
-    public JNettyTcpConnector() {}
+    public JNettyTcpConnector() {
+    	super();
+    }
 
     public JNettyTcpConnector(boolean isNative) {
         super(isNative);

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <curator.version>2.9.1</curator.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <spring-framework.version>4.3.0.RELEASE</spring-framework.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
1、增加JNettyTcpConnector默认构造方法显示调用父类NettyTcpConnector默认构造方法

2、增加jupiter/pom.xml中properties的project.build.sourceEncoding属性，设置UTF-8编码，避免maven编译【[WARNING] Using platform encoding (GBK actually) to copy filtered resources, i.e.build is platform dependent!】信息