### PR TITLE
(feat) try to minimize flush operations as much as possible

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,10 @@
 Jupiter release notes
 ------------------------
 
+### 2019-06-01: version 1.3.1-SNAPSHOT
+- InvokeType.SYNC 合并进 InvokeType.AUTO, 同时支持同步调用以及 CompletableFuture 返回值的异步调用
+- 减少 send system call 调用，性能有一定提升，验证阶段
+
 ### 2019-04-13: version 1.3.0
 - 不再支持 java7，仅支持 java8 及以上版本
 - 移除 AbstractFuture，直接使用 java8 的CompletableFuture

--- a/jupiter-all/pom.xml
+++ b/jupiter-all/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jupiter-rpc</groupId>
         <artifactId>jupiter</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-common/pom.xml
+++ b/jupiter-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-example/pom.xml
+++ b/jupiter-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-extension/jupiter-extension-tracing/pom.xml
+++ b/jupiter-extension/jupiter-extension-tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-extension</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-extension/pom.xml
+++ b/jupiter-extension/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-flightexec/pom.xml
+++ b/jupiter-flightexec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-monitor/pom.xml
+++ b/jupiter-monitor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-registry/jupiter-registry-api/pom.xml
+++ b/jupiter-registry/jupiter-registry-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-registry</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-registry/jupiter-registry-default/pom.xml
+++ b/jupiter-registry/jupiter-registry-default/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-registry</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-registry/jupiter-registry-zookeeper/pom.xml
+++ b/jupiter-registry/jupiter-registry-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-registry</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-registry/pom.xml
+++ b/jupiter-registry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-rpc/pom.xml
+++ b/jupiter-rpc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-serialization/jupiter-serialization-api/pom.xml
+++ b/jupiter-serialization/jupiter-serialization-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-serialization</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-serialization/jupiter-serialization-hessian/pom.xml
+++ b/jupiter-serialization/jupiter-serialization-hessian/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-serialization</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-serialization/jupiter-serialization-java/pom.xml
+++ b/jupiter-serialization/jupiter-serialization-java/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-serialization</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-serialization/jupiter-serialization-kryo/pom.xml
+++ b/jupiter-serialization/jupiter-serialization-kryo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-serialization</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-serialization/jupiter-serialization-protostuff/pom.xml
+++ b/jupiter-serialization/jupiter-serialization-protostuff/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-serialization</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-serialization/pom.xml
+++ b/jupiter-serialization/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-spring-support/pom.xml
+++ b/jupiter-spring-support/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-transport/jupiter-transport-api/pom.xml
+++ b/jupiter-transport/jupiter-transport-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-transport</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-transport/jupiter-transport-netty/pom.xml
+++ b/jupiter-transport/jupiter-transport-netty/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter-transport</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyDomainAcceptor.java
+++ b/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyDomainAcceptor.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.flush.FlushConsolidationHandler;
 
 import org.jupiter.common.util.JConstants;
 import org.jupiter.common.util.Requires;
@@ -114,6 +115,7 @@ public class JNettyDomainAcceptor extends NettyDomainAcceptor {
                         idleStateTrigger,
                         CodecConfig.isCodecLowCopy() ? new LowCopyProtocolDecoder() : new ProtocolDecoder(),
                         encoder,
+                        new FlushConsolidationHandler(512, true),
                         handler);
             }
         });

--- a/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyDomainConnector.java
+++ b/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyDomainConnector.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.flush.FlushConsolidationHandler;
 
 import org.jupiter.common.util.JConstants;
 import org.jupiter.common.util.Requires;
@@ -151,6 +152,7 @@ public class JNettyDomainConnector extends NettyDomainConnector {
                         idleStateTrigger,
                         CodecConfig.isCodecLowCopy() ? new LowCopyProtocolDecoder() : new ProtocolDecoder(),
                         encoder,
+                        new FlushConsolidationHandler(512, true),
                         handler
                 };
             }

--- a/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyTcpAcceptor.java
+++ b/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyTcpAcceptor.java
@@ -22,6 +22,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandler;
+import io.netty.handler.flush.FlushConsolidationHandler;
 
 import org.jupiter.common.util.JConstants;
 import org.jupiter.common.util.Requires;
@@ -159,6 +160,7 @@ public class JNettyTcpAcceptor extends NettyTcpAcceptor {
                         idleStateTrigger,
                         CodecConfig.isCodecLowCopy() ? new LowCopyProtocolDecoder() : new ProtocolDecoder(),
                         encoder,
+                        new FlushConsolidationHandler(512, true),
                         handler);
             }
         });

--- a/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyTcpConnector.java
+++ b/jupiter-transport/jupiter-transport-netty/src/main/java/org/jupiter/transport/netty/JNettyTcpConnector.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandler;
+import io.netty.handler.flush.FlushConsolidationHandler;
 
 import org.jupiter.common.util.JConstants;
 import org.jupiter.common.util.Requires;
@@ -160,6 +161,7 @@ public class JNettyTcpConnector extends NettyTcpConnector {
                         idleStateTrigger,
                         CodecConfig.isCodecLowCopy() ? new LowCopyProtocolDecoder() : new ProtocolDecoder(),
                         encoder,
+                        new FlushConsolidationHandler(512, true),
                         handler
                 };
             }

--- a/jupiter-transport/pom.xml
+++ b/jupiter-transport/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jupiter</artifactId>
         <groupId>org.jupiter-rpc</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>jupiter</artifactId>
     <groupId>org.jupiter-rpc</groupId>
     <packaging>pom</packaging>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
 
     <name>Jupiter</name>
     <description>Jupiter is a distributed RPC framework.</description>


### PR DESCRIPTION
### Motivation:

Flush operations are generally speaking expensive as these may trigger a syscall on the transport level. Thus it is in most cases (where write latency can be traded with throughput) a good idea to try to minimize flush operations as much as possible.

If we call writeAndFlush, queue would look like:

`write1, flush, write2, flush`

And for higher performance, after writeAndFlush queue should be:

`write1, write2, flush`

### Modification:

add [FlushConsolidationHandler](https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java)

### Result:
